### PR TITLE
fix masternode ping processing

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -1005,7 +1005,8 @@ bool CMasternodePing::CheckAndUpdate(CMasternode* pmn, bool fFromNewBroadcast, i
             return false;
         }
 
-        if (pmn->IsNewStartRequired()) {
+        // allow pinging node after NSR to recover automatically if not completely expired
+        if (pmn->IsExpired()) {
             LogPrint(BCLog::MASTERNODE, "CMasternodePing::CheckAndUpdate -- masternode is completely expired, new start is required, masternode=%s\n", vin.prevout.ToStringShort());
             return false;
         }
@@ -1014,7 +1015,8 @@ bool CMasternodePing::CheckAndUpdate(CMasternode* pmn, bool fFromNewBroadcast, i
     {
         LOCK(cs_main);
         BlockMap::iterator mi = mapBlockIndex.find(blockHash);
-        if ((*mi).second && (*mi).second->nHeight < chainActive.Height() - 24) {
+        // fix hardcoded Dash value for ping age validation to reflect block spacing in chainparams
+        if ((*mi).second && (*mi).second->nHeight < chainActive.Height() - (MASTERNODE_NEW_START_REQUIRED_SECONDS / Params().GetConsensus().nPowTargetSpacing)) {
             LogPrintf("CMasternodePing::CheckAndUpdate -- Masternode ping is invalid, block hash is too old: masternode=%s  blockHash=%s\n", vin.prevout.ToStringShort(), blockHash.ToString());
             // nDos = 1;
             return false;

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -915,7 +915,8 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, const std::string& strCommand,
             UpdateWatchdogVoteTime(mnp.vin.prevout, mnp.sigTime);
 
         // too late, new MNANNOUNCE is required
-        if(pmn && pmn->IsNewStartRequired()) return;
+        // allow ping processing after NSR to recover node automatically if not totally expired
+        if(pmn && pmn->IsExpired()) return;
 
         int nDos = 0;
         if(mnp.CheckAndUpdate(pmn, false, nDos, connman)) return;


### PR DESCRIPTION
Fix is solving two problems:
- hardcoded Dash value is improper for other block spacings than original Dash one which caused even valid pings were considered invalid and node state was changed to NSR even when it was still providing valid pings to network
- masternode was considered expired even before Expired state, NSR state can be safely recovered to Enabled if node is still providing valid pings to network - this will allow to get masternodes in incorrect NSR state back to Enabled automatically