### PR TITLE
reducing wallet interface lags

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -6,7 +6,7 @@
 #define BITCOIN_QT_GUICONSTANTS_H
 
 /* Milliseconds between model updates */
-static const int MODEL_UPDATE_DELAY = 250;
+static const int MODEL_UPDATE_DELAY = 5000;
 
 /* AskPassphraseDialog -- Maximum passphrase length */
 static const int MAX_PASSPHRASE_SIZE = 1024;


### PR DESCRIPTION
Reducing the lag of the wallet interface to zero.
For example, on the risen 3600 processor, the load decreased from 7% to near-zero values.
One of the disadvantages is that the blockchain information in the wallet is updated every 5 seconds.