### PR TITLE
Docs - MacOS Bootstrap proposal

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -38,7 +38,7 @@ mv -f ~/bootstrap/* ~/Library/Application\ Support/SIN/
 # remove unnecessary files
 rm -rf ~/{bootstrap,bootstrap.zip}
 ````
-
+- Open the SIN wallet again.
 
 ## Linux CLI Bootstrap
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -27,13 +27,16 @@ If you need to quickly synchronize your MacOS wallet, follow the steps below:
 wget -O ~/bootstrap.zip https://service.sinovate.io/mainnet/latest/bootstrap.zip
 
 # remove old files and folders
-rm -rf ~/Library/Application\ Support/SIN/{blocks,chainstate,txindex,infinitynode.dat,infinitynodelockinfo.dat,infinitynodemeta.dat,infinitynodersv.dat}
+rm -rf ~/Library/Application\ Support/SIN/{blocks,chainstate,indexes,infinitynode.dat,infinitynodelockinfo.dat,infinitynodemeta.dat,infinitynodersv.dat}
 
 # unzip the bootstrap archive
-unzip ~/bootstrap.zip -d ~/Library/Application\ Support/SIN/
+unzip ~/bootstrap.zip
+
+# move bootstrap files
+mv -f ~/bootstrap/* ~/Library/Application\ Support/SIN/  
 
 # remove unnecessary files
-rm -rf ~/bootstrap.zip
+rm -rf ~/{bootstrap,bootstrap.zip}
 ````
 
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -23,13 +23,13 @@ If you need to quickly synchronize your MacOS wallet, follow the steps below:
 - Close the SIN wallet and run the commands below in Terminal:
 
 ```bash
-# Download latest bootstrap archive
+# download latest bootstrap archive
 wget -O ~/bootstrap.zip https://service.sinovate.io/mainnet/latest/bootstrap.zip
 
 # remove old files and folders
 rm -rf ~/Library/Application\ Support/SIN/{blocks,chainstate,txindex,infinitynode.dat,infinitynodelockinfo.dat,infinitynodemeta.dat,infinitynodersv.dat}
 
-# Unzip the bootstrap archive
+# unzip the bootstrap archive
 unzip ~/bootstrap.zip -d ~/Library/Application\ Support/SIN/
 
 # remove unnecessary files

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -16,6 +16,27 @@ https://service.sinovate.io/mainnet/latest/bootstrap.zip
 - Move the `blocks`, `chainstate`, indexes folders and infinitynode dat files inside the SIN folder at `%appdata%\SIN\`
 - Open the local wallet again.
 
+## MacOS Bootstrap
+
+If you need to quickly synchronize your MacOS wallet, follow the steps below:
+
+- Close the SIN wallet and run the commands below in Terminal:
+
+```bash
+# Download latest bootstrap archive
+wget -O ~/bootstrap.zip https://service.sinovate.io/mainnet/latest/bootstrap.zip
+
+# remove old files and folders
+rm -rf ~/Library/Application\ Support/SIN/{blocks,chainstate,txindex,infinitynode.dat,infinitynodelockinfo.dat,infinitynodemeta.dat,infinitynodersv.dat}
+
+# Unzip the bootstrap archive
+unzip ~/bootstrap.zip -d ~/Library/Application\ Support/SIN/
+
+# remove unnecessary files
+rm -rf ~/bootstrap.zip
+````
+
+
 ## Linux CLI Bootstrap
 
 :warning: You must log in with the user you created during installation.


### PR DESCRIPTION
Hi!
I've proposed a change to the docs/bootstrap.m file to contain information regarding bootstraping on MacOS.
There was no information regarding bootstraping on MacOS within the [docs.sinovate.io ](https://docs.sinovate.io)site so I've created a proposal to one.

I experienced problems with syncronization of the SIN wallet and my proposed precedure resolved my issue. I see in the documentation regarding Linux CLI Bootstrap that there is additional files removed in one of the commands. The additional files which I have _not_ removed in the proposed code is listed below:
- debug.log
- mnpayments.dat
- mncache.dat
- banlist.dat
- peers.dat
- netfulfilled.dat
- governance.dat
- fee_estimates.dat

I do not know how much problem these files can create, but please add them to the _rm_ command if it is better to remove them.

Cheers!